### PR TITLE
Store drafts directly in the res.locals map

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/cmc-draft-store-middleware",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Node.js middleware for draft store",
   "engines": {
     "node": ">=8.0.0"

--- a/src/main/middleware/draftMiddleware.ts
+++ b/src/main/middleware/draftMiddleware.ts
@@ -68,7 +68,7 @@ export class DraftMiddleware {
           if (draftIsMissingExternalId(draft) && externalId !== undefined) {
             draft.document.externalId = externalId
           }
-          res.locals.user[`${draftType}Draft`] = draft
+          res.locals[`${draftType}Draft`] = draft
 
           next()
         } catch (err) {

--- a/src/test/middleware/draftMiddleware.ts
+++ b/src/test/middleware/draftMiddleware.ts
@@ -63,12 +63,12 @@ describe('Draft middleware', () => {
         draftService.find.returns(Promise.resolve([]))
 
         await DraftMiddleware.requestHandler(draftService as any, 'default', 100)(req, res, next)
-        chai.expect(res.locals.user.defaultDraft).to.be.instanceof(Draft)
-        chai.expect(res.locals.user.defaultDraft.id).to.be.equal(0)
-        chai.expect(res.locals.user.defaultDraft.type).to.be.equal('default')
-        chai.expect(res.locals.user.defaultDraft.document).to.be.undefined
-        chai.expect(res.locals.user.defaultDraft.created).to.be.not.undefined
-        chai.expect(res.locals.user.defaultDraft.updated).to.be.not.undefined
+        chai.expect(res.locals.defaultDraft).to.be.instanceof(Draft)
+        chai.expect(res.locals.defaultDraft.id).to.be.equal(0)
+        chai.expect(res.locals.defaultDraft.type).to.be.equal('default')
+        chai.expect(res.locals.defaultDraft.document).to.be.undefined
+        chai.expect(res.locals.defaultDraft.created).to.be.not.undefined
+        chai.expect(res.locals.defaultDraft.updated).to.be.not.undefined
         chai.expect(next).to.have.been.calledOnce
         chai.expect(next.firstCall.args).to.be.empty
       })
@@ -81,12 +81,12 @@ describe('Draft middleware', () => {
         ]))
 
         await DraftMiddleware.requestHandler(draftService as any, 'default', 100)(req, res, next)
-        chai.expect(res.locals.user.defaultDraft).to.be.instanceof(Draft)
-        chai.expect(res.locals.user.defaultDraft.id).to.be.equal(0)
-        chai.expect(res.locals.user.defaultDraft.type).to.be.equal('default')
-        chai.expect(res.locals.user.defaultDraft.document).to.be.undefined
-        chai.expect(res.locals.user.defaultDraft.created).to.be.not.undefined
-        chai.expect(res.locals.user.defaultDraft.updated).to.be.not.undefined
+        chai.expect(res.locals.defaultDraft).to.be.instanceof(Draft)
+        chai.expect(res.locals.defaultDraft.id).to.be.equal(0)
+        chai.expect(res.locals.defaultDraft.type).to.be.equal('default')
+        chai.expect(res.locals.defaultDraft.document).to.be.undefined
+        chai.expect(res.locals.defaultDraft.created).to.be.not.undefined
+        chai.expect(res.locals.defaultDraft.updated).to.be.not.undefined
         chai.expect(next).to.have.been.calledOnce
         chai.expect(next.firstCall.args).to.be.empty
       })
@@ -96,7 +96,7 @@ describe('Draft middleware', () => {
         draftService.find.returns(Promise.resolve([draft]))
 
         await DraftMiddleware.requestHandler(draftService as any, 'default', 100)(req, res, next)
-        chai.expect(res.locals.user.defaultDraft).to.be.equal(draft)
+        chai.expect(res.locals.defaultDraft).to.be.equal(draft)
         chai.expect(next).to.have.been.calledOnce
         chai.expect(next.firstCall.args).to.be.empty
       })
@@ -108,7 +108,7 @@ describe('Draft middleware', () => {
         ]))
 
         await DraftMiddleware.requestHandler(draftService as any, 'default', 100)(req, res, next)
-        chai.expect(res.locals.user.defaultDraft).to.be.undefined
+        chai.expect(res.locals.defaultDraft).to.be.undefined
         chai.expect(next).to.have.been.calledOnce
         chai.expect(next.firstCall.args).to.be.lengthOf(1)
         chai.expect(next.firstCall.args[0]).to.be.instanceof(Error)


### PR DESCRIPTION
This PR stores drafts directly in `res.locals` scope. Storing drafts in user scope has the following drawbacks:

1. drafts and other elements of the local application state are not really something that describes a user and as such should not be there - it only makes user class grow as application grows
2. current middleware implementation forces any application consuming `cmc-draft-store-middleware` module to to store drafts within user object which enforces questioned data structure onto other project teams 
3. it raises unnecessary question whether to assign user object to variable and access its draft properties to or maybe reaching for drafts directly
